### PR TITLE
Automate alt text for figures

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: csasdown
 Title: Reproducible CSAS Reports
-Version: 0.0.0.90023
+Version: 0.0.0.90024
 Authors@R: c(
     person(c("Sean", "C."), "Anderson", , "sean@seananderson.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-9563-1937")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: csasdown
 Title: Reproducible CSAS Reports
-Version: 0.0.0.90024
+Version: 0.0.0.90025
 Authors@R: c(
     person(c("Sean", "C."), "Anderson", , "sean@seananderson.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-9563-1937")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: csasdown
 Title: Reproducible CSAS Reports
-Version: 0.0.0.90025
+Version: 0.0.0.90024
 Authors@R: c(
     person(c("Sean", "C."), "Anderson", , "sean@seananderson.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-9563-1937")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # csasdown development version
 
+## csasdown 0.0.0.90025
+
+* Keep automatic figure alt-text numbering aligned after chunks with explicit
+  `fig.alt` values.
+
 ## csasdown 0.0.0.90024
 
 * Add automatic CSAS figure alt text for numbered figures rendered through

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,5 @@
 # csasdown development version
 
-## csasdown 0.0.0.90025
-
-* Keep automatic figure alt-text numbering aligned after chunks with explicit
-  `fig.alt` values.
-
 ## csasdown 0.0.0.90024
 
 * Add automatic CSAS figure alt text for numbered figures rendered through

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@
 ## csasdown 0.0.0.90024
 
 * Add automatic CSAS figure alt text for numbered figures rendered through
-  knitr chunk options.
+  knitr chunk options, replacing custom `fig.alt` values with a warning when
+  needed to keep alt text aligned with CSAS formatting conventions.
 
 ## csasdown 0.0.0.90022
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # csasdown development version
 
+## csasdown 0.0.0.90024
+
+* Add automatic CSAS figure alt text for numbered figures rendered through
+  knitr chunk options.
+
 ## csasdown 0.0.0.90022
 
 * Rework resdoc abstract handling to capture and evaluate the abstract from a

--- a/R/docx-utils.R
+++ b/R/docx-utils.R
@@ -1235,7 +1235,25 @@ insert_section_break_after_abstract <- function(docx_path, french = FALSE) {
 make_auto_fig_alt_hook <- function() {
   fig_counters <- new.env(parent = emptyenv())
   fig_counters$main <- 0L
+  fig_counters$warned <- FALSE
   appendix_fig_counters <- new.env(parent = emptyenv())
+
+  set_fig_alt <- function(options, fig_alt) {
+    if (!is.null(options$fig.alt) && identical(as.character(options$fig.alt), fig_alt)) {
+      return(options)
+    }
+    if (!is.null(options$fig.alt) && !fig_counters$warned) {
+      cli::cli_warn(c(
+        "csasdown automatically sets figure alt text to CSAS figure numbers.",
+        "i" = "User-supplied {.code fig.alt} values are being replaced.",
+        "i" = "Set {.code auto_alt_text = FALSE} to manage figure alt text manually."
+      ))
+      fig_counters$warned <- TRUE
+    }
+    options$fig.alt <- fig_alt
+    if (length(options$fig.alt) == 1L) options$fig.alt <- options$fig.alt[1]
+    options
+  }
 
   function(options) {
     if (!isTRUE(options$auto_alt_text)) return(options)
@@ -1265,18 +1283,12 @@ make_auto_fig_alt_hook <- function() {
       }
       figure_numbers <- current + seq_len(fig_count)
       appendix_fig_counters[[appendix_letter]] <- max(figure_numbers)
-      if (!is.null(options$fig.alt)) return(options)
-      options$fig.alt <- paste0("Figure ", appendix_letter, figure_numbers)
-      if (length(options$fig.alt) == 1L) options$fig.alt <- options$fig.alt[1]
-      return(options)
+      return(set_fig_alt(options, paste0("Figure ", appendix_letter, figure_numbers)))
     }
 
     figure_numbers <- fig_counters$main + seq_len(fig_count)
     fig_counters$main <- max(figure_numbers)
-    if (!is.null(options$fig.alt)) return(options)
-    options$fig.alt <- paste0("Figure ", figure_numbers)
-    if (length(options$fig.alt) == 1L) options$fig.alt <- options$fig.alt[1]
-    options
+    set_fig_alt(options, paste0("Figure ", figure_numbers))
   }
 }
 

--- a/R/docx-utils.R
+++ b/R/docx-utils.R
@@ -1233,12 +1233,12 @@ insert_section_break_after_abstract <- function(docx_path, french = FALSE) {
 }
 
 make_auto_fig_alt_hook <- function() {
-  fig_counter <- 0L
+  fig_counters <- new.env(parent = emptyenv())
+  fig_counters$main <- 0L
   appendix_fig_counters <- new.env(parent = emptyenv())
 
   function(options) {
     if (!isTRUE(options$auto_alt_text)) return(options)
-    if (!is.null(options$fig.alt)) return(options)
     if (is.null(options$fig.cap)) return(options)
 
     captions <- options$fig.cap
@@ -1265,13 +1265,15 @@ make_auto_fig_alt_hook <- function() {
       }
       figure_numbers <- current + seq_len(fig_count)
       appendix_fig_counters[[appendix_letter]] <- max(figure_numbers)
+      if (!is.null(options$fig.alt)) return(options)
       options$fig.alt <- paste0("Figure ", appendix_letter, figure_numbers)
       if (length(options$fig.alt) == 1L) options$fig.alt <- options$fig.alt[1]
       return(options)
     }
 
-    figure_numbers <- fig_counter + seq_len(fig_count)
-    fig_counter <<- max(figure_numbers)
+    figure_numbers <- fig_counters$main + seq_len(fig_count)
+    fig_counters$main <- max(figure_numbers)
+    if (!is.null(options$fig.alt)) return(options)
     options$fig.alt <- paste0("Figure ", figure_numbers)
     if (length(options$fig.alt) == 1L) options$fig.alt <- options$fig.alt[1]
     options

--- a/R/docx-utils.R
+++ b/R/docx-utils.R
@@ -1232,6 +1232,52 @@ insert_section_break_after_abstract <- function(docx_path, french = FALSE) {
   invisible(docx_path)
 }
 
+make_auto_fig_alt_hook <- function() {
+  fig_counter <- 0L
+  appendix_fig_counters <- new.env(parent = emptyenv())
+
+  function(options) {
+    if (!isTRUE(options$auto_alt_text)) return(options)
+    if (!is.null(options$fig.alt)) return(options)
+    if (is.null(options$fig.cap)) return(options)
+
+    captions <- options$fig.cap
+    captions <- captions[!is.na(captions)]
+    if (!length(captions)) return(options)
+
+    fig_count <- length(captions)
+    fig_cap_pre <- options$fig.cap.pre
+    appendix_letter <- NULL
+    if (!is.null(fig_cap_pre) && length(fig_cap_pre) && !is.na(fig_cap_pre[1])) {
+      appendix_match <- regexec("^Figure ([A-Z])\\.?$", fig_cap_pre[1], perl = TRUE)
+      appendix_parts <- regmatches(fig_cap_pre[1], appendix_match)[[1]]
+      if (length(appendix_parts) == 2L) {
+        appendix_letter <- appendix_parts[2]
+      }
+    }
+
+    if (!is.null(appendix_letter)) {
+      current <- appendix_fig_counters[[appendix_letter]]
+      if (is.null(current)) {
+        start_at <- suppressWarnings(as.integer(options$fig.autonum.start_at))
+        if (length(start_at) != 1L || is.na(start_at)) start_at <- 1L
+        current <- start_at - 1L
+      }
+      figure_numbers <- current + seq_len(fig_count)
+      appendix_fig_counters[[appendix_letter]] <- max(figure_numbers)
+      options$fig.alt <- paste0("Figure ", appendix_letter, figure_numbers)
+      if (length(options$fig.alt) == 1L) options$fig.alt <- options$fig.alt[1]
+      return(options)
+    }
+
+    figure_numbers <- fig_counter + seq_len(fig_count)
+    fig_counter <<- max(figure_numbers)
+    options$fig.alt <- paste0("Figure ", figure_numbers)
+    if (length(options$fig.alt) == 1L) options$fig.alt <- options$fig.alt[1]
+    options
+  }
+}
+
 #' Base function for creating CSAS docx output formats
 #'
 #' @description Internal function that contains shared logic for all CSAS docx
@@ -1339,6 +1385,7 @@ insert_section_break_after_abstract <- function(docx_path, french = FALSE) {
   base$knitr$opts_chunk$comment <- "#>"
   base$knitr$opts_chunk$dev <- "png"
   base$knitr$opts_chunk$auto_asp <- TRUE
+  base$knitr$opts_chunk$auto_alt_text <- TRUE
 
   base$knitr$opts_hooks$auto_asp <- function(options) {
     if (!isTRUE(options$auto_asp)) return(options)
@@ -1363,6 +1410,7 @@ insert_section_break_after_abstract <- function(docx_path, french = FALSE) {
     options$fig.asp <- dims$height / dims$width
     options
   }
+  base$knitr$opts_hooks$auto_alt_text <- make_auto_fig_alt_hook()
 
   base <- add_caption_fix_postprocessor(base, reference_docx = ref_docx_path)
 

--- a/tests/testthat/test-auto-alt-text.R
+++ b/tests/testthat/test-auto-alt-text.R
@@ -15,35 +15,68 @@ test_that("auto_alt_text numbers main document figures", {
   expect_equal(second$fig.alt, "Figure 2")
 })
 
-test_that("auto_alt_text preserves explicit fig.alt", {
+test_that("auto_alt_text preserves matching explicit fig.alt", {
   output <- resdoc_docx()
   hook <- output$knitr$opts_hooks$auto_alt_text
 
   options <- hook(list(
     auto_alt_text = TRUE,
     fig.cap = "First figure.",
-    fig.alt = "Custom figure alt text"
+    fig.alt = "Figure 1"
   ))
   next_options <- hook(list(
     auto_alt_text = TRUE,
     fig.cap = "Second figure."
   ))
 
-  expect_equal(options$fig.alt, "Custom figure alt text")
+  expect_equal(options$fig.alt, "Figure 1")
   expect_equal(next_options$fig.alt, "Figure 2")
 })
 
-test_that("auto_alt_text advances appendix counters with explicit fig.alt", {
+test_that("auto_alt_text warns once and replaces custom fig.alt", {
   output <- resdoc_docx()
   hook <- output$knitr$opts_hooks$auto_alt_text
 
-  options <- hook(list(
+  options <- expect_warning(
+    hook(list(
+      auto_alt_text = TRUE,
+      fig.cap = "First figure.",
+      fig.alt = "Custom figure alt text"
+    )),
+    "csasdown automatically sets figure alt text"
+  )
+  next_custom <- expect_warning(
+    hook(list(
+      auto_alt_text = TRUE,
+      fig.cap = "Second figure.",
+      fig.alt = "Another custom alt text"
+    )),
+    NA
+  )
+  next_options <- hook(list(
     auto_alt_text = TRUE,
-    fig.cap = "First appendix figure.",
-    fig.cap.pre = "Figure A.",
-    fig.autonum.start_at = 1,
-    fig.alt = "Custom appendix alt text"
+    fig.cap = "Third figure."
   ))
+
+  expect_equal(options$fig.alt, "Figure 1")
+  expect_equal(next_custom$fig.alt, "Figure 2")
+  expect_equal(next_options$fig.alt, "Figure 3")
+})
+
+test_that("auto_alt_text replaces custom appendix fig.alt", {
+  output <- resdoc_docx()
+  hook <- output$knitr$opts_hooks$auto_alt_text
+
+  options <- expect_warning(
+    hook(list(
+      auto_alt_text = TRUE,
+      fig.cap = "First appendix figure.",
+      fig.cap.pre = "Figure A.",
+      fig.autonum.start_at = 1,
+      fig.alt = "Custom appendix alt text"
+    )),
+    "csasdown automatically sets figure alt text"
+  )
   next_options <- hook(list(
     auto_alt_text = TRUE,
     fig.cap = "Second appendix figure.",
@@ -51,7 +84,7 @@ test_that("auto_alt_text advances appendix counters with explicit fig.alt", {
     fig.autonum.start_at = 1
   ))
 
-  expect_equal(options$fig.alt, "Custom appendix alt text")
+  expect_equal(options$fig.alt, "Figure A1")
   expect_equal(next_options$fig.alt, "Figure A2")
 })
 

--- a/tests/testthat/test-auto-alt-text.R
+++ b/tests/testthat/test-auto-alt-text.R
@@ -37,16 +37,16 @@ test_that("auto_alt_text warns once and replaces custom fig.alt", {
   output <- resdoc_docx()
   hook <- output$knitr$opts_hooks$auto_alt_text
 
-  options <- expect_warning(
-    hook(list(
+  expect_warning(
+    options <- hook(list(
       auto_alt_text = TRUE,
       fig.cap = "First figure.",
       fig.alt = "Custom figure alt text"
     )),
     "csasdown automatically sets figure alt text"
   )
-  next_custom <- expect_warning(
-    hook(list(
+  expect_warning(
+    next_custom <- hook(list(
       auto_alt_text = TRUE,
       fig.cap = "Second figure.",
       fig.alt = "Another custom alt text"
@@ -67,8 +67,8 @@ test_that("auto_alt_text replaces custom appendix fig.alt", {
   output <- resdoc_docx()
   hook <- output$knitr$opts_hooks$auto_alt_text
 
-  options <- expect_warning(
-    hook(list(
+  expect_warning(
+    options <- hook(list(
       auto_alt_text = TRUE,
       fig.cap = "First appendix figure.",
       fig.cap.pre = "Figure A.",

--- a/tests/testthat/test-auto-alt-text.R
+++ b/tests/testthat/test-auto-alt-text.R
@@ -1,0 +1,78 @@
+test_that("auto_alt_text numbers main document figures", {
+  output <- resdoc_docx()
+  hook <- output$knitr$opts_hooks$auto_alt_text
+
+  first <- hook(list(
+    auto_alt_text = TRUE,
+    fig.cap = "First figure."
+  ))
+  second <- hook(list(
+    auto_alt_text = TRUE,
+    fig.cap = "Second figure."
+  ))
+
+  expect_equal(first$fig.alt, "Figure 1")
+  expect_equal(second$fig.alt, "Figure 2")
+})
+
+test_that("auto_alt_text preserves explicit fig.alt", {
+  output <- resdoc_docx()
+
+  options <- output$knitr$opts_hooks$auto_alt_text(list(
+    auto_alt_text = TRUE,
+    fig.cap = "First figure.",
+    fig.alt = "Custom figure alt text"
+  ))
+
+  expect_equal(options$fig.alt, "Custom figure alt text")
+})
+
+test_that("auto_alt_text numbers appendix figures", {
+  output <- resdoc_docx()
+  hook <- output$knitr$opts_hooks$auto_alt_text
+
+  first <- hook(list(
+    auto_alt_text = TRUE,
+    fig.cap = "First appendix figure.",
+    fig.cap.pre = "Figure A.",
+    fig.autonum.start_at = 1
+  ))
+  second <- hook(list(
+    auto_alt_text = TRUE,
+    fig.cap = "Second appendix figure.",
+    fig.cap.pre = "Figure A.",
+    fig.autonum.start_at = 1
+  ))
+
+  expect_equal(first$fig.alt, "Figure A1")
+  expect_equal(second$fig.alt, "Figure A2")
+})
+
+test_that("auto_alt_text handles multiple figures from one chunk", {
+  output <- resdoc_docx()
+  hook <- output$knitr$opts_hooks$auto_alt_text
+
+  main <- hook(list(
+    auto_alt_text = TRUE,
+    fig.cap = c("First figure.", "Second figure.")
+  ))
+  appendix <- hook(list(
+    auto_alt_text = TRUE,
+    fig.cap = c("First appendix figure.", "Second appendix figure."),
+    fig.cap.pre = "Figure B.",
+    fig.autonum.start_at = 1
+  ))
+
+  expect_equal(main$fig.alt, c("Figure 1", "Figure 2"))
+  expect_equal(appendix$fig.alt, c("Figure B1", "Figure B2"))
+})
+
+test_that("auto_alt_text skips chunks without figure captions", {
+  output <- resdoc_docx()
+
+  options <- output$knitr$opts_hooks$auto_alt_text(list(
+    auto_alt_text = TRUE
+  ))
+
+  expect_null(options$fig.alt)
+})

--- a/tests/testthat/test-auto-alt-text.R
+++ b/tests/testthat/test-auto-alt-text.R
@@ -17,14 +17,42 @@ test_that("auto_alt_text numbers main document figures", {
 
 test_that("auto_alt_text preserves explicit fig.alt", {
   output <- resdoc_docx()
+  hook <- output$knitr$opts_hooks$auto_alt_text
 
-  options <- output$knitr$opts_hooks$auto_alt_text(list(
+  options <- hook(list(
     auto_alt_text = TRUE,
     fig.cap = "First figure.",
     fig.alt = "Custom figure alt text"
   ))
+  next_options <- hook(list(
+    auto_alt_text = TRUE,
+    fig.cap = "Second figure."
+  ))
 
   expect_equal(options$fig.alt, "Custom figure alt text")
+  expect_equal(next_options$fig.alt, "Figure 2")
+})
+
+test_that("auto_alt_text advances appendix counters with explicit fig.alt", {
+  output <- resdoc_docx()
+  hook <- output$knitr$opts_hooks$auto_alt_text
+
+  options <- hook(list(
+    auto_alt_text = TRUE,
+    fig.cap = "First appendix figure.",
+    fig.cap.pre = "Figure A.",
+    fig.autonum.start_at = 1,
+    fig.alt = "Custom appendix alt text"
+  ))
+  next_options <- hook(list(
+    auto_alt_text = TRUE,
+    fig.cap = "Second appendix figure.",
+    fig.cap.pre = "Figure A.",
+    fig.autonum.start_at = 1
+  ))
+
+  expect_equal(options$fig.alt, "Custom appendix alt text")
+  expect_equal(next_options$fig.alt, "Figure A2")
 })
 
 test_that("auto_alt_text numbers appendix figures", {


### PR DESCRIPTION
Use hooks to automate alt text for figures following CSAS formatting conventions